### PR TITLE
Fix: Update placeholder SMTP credentials in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,10 @@ REDIS_URL="redis://default:password@host:port"
 # Optional: Custom message for the /api/ping endpoint
 PING_MESSAGE="Hello from the server!"
 
-# --- Email (SMTP) Configuration for sending OTPs ---.
+# --- Email (SMTP) Configuration for sending OTPs ---
 # If these are not provided, the OTP will be logged to the console instead.
-SMTP_HOST="smtp.office365.com"
+# Replace with your actual SMTP server details.
+SMTP_HOST="smtp.example.com"
 SMTP_PORT="587"
-SMTP_USER="smtp.office365.com"
-SMTP_PASS="Officialderiv01"
+SMTP_USER="your-email@example.com"
+SMTP_PASS="your-email-password"


### PR DESCRIPTION
The previous SMTP configuration in the `.env.example` file contained misleading and potentially insecure values. The `SMTP_USER` was incorrectly set to the SMTP host, and the password was a non-obvious placeholder.

This commit updates the `.env.example` file to use clear, generic placeholders for the SMTP settings (`SMTP_HOST`, `SMTP_USER`, `SMTP_PASS`). This makes it easier and safer for developers to configure the email OTP feature.