### PR TITLE
feat: Implement email OTP verification page

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -10,6 +10,7 @@ import Index from "./pages/Index";
 import CorporateIndex from "./pages/CorporateIndex";
 import Success from "./pages/Success";
 import NotFound from "./pages/NotFound";
+import OtpPage from "./pages/OtpPage";
 
 const queryClient = new QueryClient();
 
@@ -23,6 +24,7 @@ const App = () => (
           <Route path="/" element={<Index />} />
           <Route path="/corporate" element={<CorporateIndex />} />
           <Route path="/success" element={<Success />} />
+          <Route path="/otp" element={<OtpPage />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/client/pages/OtpPage.tsx
+++ b/client/pages/OtpPage.tsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp';
+import { useToast } from '@/components/ui/use-toast';
+import { Toaster } from '@/components/ui/toaster';
+
+const OtpPage: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [otp, setOtp] = useState('');
+  const [isOtpSent, setIsOtpSent] = useState(false);
+  const { toast } = useToast();
+
+  const handleSendOtp = async () => {
+    try {
+      const response = await fetch('/api/otp/send', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        setIsOtpSent(true);
+        toast({
+          title: 'Success',
+          description: 'OTP sent to your email address.',
+        });
+      } else {
+        toast({
+          title: 'Error',
+          description: data.message || 'Failed to send OTP.',
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description: 'An unexpected error occurred.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleVerifyOtp = async () => {
+    try {
+      const response = await fetch('/api/otp/verify', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, otp }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        toast({
+          title: 'Success',
+          description: 'OTP verified successfully!',
+        });
+      } else {
+        toast({
+          title: 'Error',
+          description: data.message || 'Failed to verify OTP.',
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description: 'An unexpected error occurred.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+      <Toaster />
+      <div className="w-full max-w-md p-8 space-y-6 bg-white rounded-lg shadow-md">
+        <h1 className="text-2xl font-bold text-center">Email Verification</h1>
+        {!isOtpSent ? (
+          <div className="space-y-4">
+            <div>
+              <label htmlFor="email" className="text-sm font-medium text-gray-700">
+                Email Address
+              </label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="mt-1"
+              />
+            </div>
+            <Button onClick={handleSendOtp} className="w-full">
+              Send OTP
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <p className="text-center text-gray-600">
+              An OTP has been sent to <strong>{email}</strong>. Please enter it below.
+            </p>
+            <div className="flex justify-center">
+                <InputOTP maxLength={6} value={otp} onChange={setOtp}>
+                    <InputOTPGroup>
+                        <InputOTPSlot index={0} />
+                        <InputOTPSlot index={1} />
+                        <InputOTPSlot index={2} />
+                        <InputOTPSlot index={3} />
+                        <InputOTPSlot index={4} />
+                        <InputOTPSlot index={5} />
+                    </InputOTPGroup>
+                </InputOTP>
+            </div>
+            <Button onClick={handleVerifyOtp} className="w-full">
+              Verify OTP
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default OtpPage;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import { createServer } from "./server";
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   server: {
-    host: "::",
+    host: "0.0.0.0",
     port: 8080,
     fs: {
       allow: ["./client", "./shared"],


### PR DESCRIPTION
This commit introduces a new page for email OTP verification, completing the email OTP feature.

The following changes are included:
- A new page component `client/pages/OtpPage.tsx` is created to handle the UI and logic for OTP verification.
- The page uses the existing `InputOTP` component and connects to the backend API endpoints `/api/otp/send` and `/api/otp/verify`.
- A new route `/otp` is added to `client/App.tsx` to make the OTP page accessible.
- The Vite development server configuration was updated to use `0.0.0.0` as the host to ensure compatibility with containerized environments.

The existing test suite passes, but the test runner (`vitest`) does not exit cleanly after the tests are complete. This appears to be due to the Redis client not closing its connection properly. This is a pre-existing issue and is not resolved in this commit.