### PR TITLE
fix(otp): Use console fallback for placeholder SMTP credentials

### DIFF
--- a/server/routes/otp.ts
+++ b/server/routes/otp.ts
@@ -8,7 +8,10 @@ import { Analytics } from "../utils/logger";
 
 // --- Nodemailer Transport Setup ---
 const useRealEmailService =
-  process.env.SMTP_HOST && process.env.SMTP_USER && process.env.SMTP_PASS;
+  process.env.SMTP_HOST &&
+  process.env.SMTP_USER &&
+  process.env.SMTP_PASS &&
+  process.env.SMTP_USER !== "hybe.supp0rt@hotmail.com";
 
 const transporter = useRealEmailService
   ? nodemailer.createTransport({


### PR DESCRIPTION
This commit refines the logic for sending OTPs. Previously, the system would attempt to use the SMTP service if the `SMTP_HOST`, `SMTP_USER`, and `SMTP_PASS` environment variables were present, even if they held placeholder values from the example configuration.

This led to an error when the placeholder credentials for `hybe.supp0rt@hotmail.com` were used, causing the OTP sending to fail instead of gracefully falling back to the intended console logging mechanism for development environments.

The updated logic now includes a check to see if `SMTP_USER` is set to the placeholder email. If it is, the system will now correctly use the console fallback, ensuring that the OTP feature is usable in development setups without requiring valid SMTP credentials.