### PR TITLE
fix: Correct order of commands in build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "npm run build:client && npm run build:server && npm run copy:templates",
+    "build": "npm run build:client && npm run copy:templates && npm run build:server",
     "build:client": "vite build",
     "copy:templates": "cpx2 \"src/email-templates/**/*\" dist/email-templates",
     "build:server": "vite build --config vite.config.server.ts",


### PR DESCRIPTION
- Reordered the `build` script in `package.json` to run `copy:templates` before `build:server`.
- This resolves a race condition where the server build would fail because it tried to access the template files before they were copied to the `dist` directory.