### PR TITLE
fix: Defer template file reading to runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "npm run build:client && npm run copy:templates && npm run build:server",
+    "build": "npm run build:client && npm run build:server && npm run copy:templates",
     "build:client": "vite build",
     "copy:templates": "cpx2 \"src/email-templates/**/*\" dist/email-templates",
     "build:server": "vite build --config vite.config.server.ts",

--- a/server/routes/otp.ts
+++ b/server/routes/otp.ts
@@ -23,14 +23,6 @@ const transporter = useRealEmailService
     })
   : null;
 
-// --- Email Template ---
-const isProd = process.env.NODE_ENV === "production";
-// In production, templates are copied to `dist`. In dev, they are in `src`.
-const templateDir = isProd ? "dist/email-templates" : "src/email-templates";
-const templatePath = path.join(process.cwd(), templateDir, "otp-template.hbs");
-const templateSource = fs.readFileSync(templatePath, "utf-8");
-const emailTemplate = Handlebars.compile(templateSource);
-
 // --- Constants ---
 const OTP_EXPIRATION_SECONDS = 300; // 5 minutes
 const OTP_RESEND_COOLDOWN_SECONDS = 60; // 1 minute
@@ -74,6 +66,12 @@ export const handleSendOtp: RequestHandler = async (req, res) => {
     await cacheService.del(`otp_verify_attempts:${email}`);
 
     // --- Send Email or Log to Console ---
+    const isProd = process.env.NODE_ENV === "production";
+    const templateDir = isProd ? "dist/email-templates" : "src/email-templates";
+    const templatePath = path.join(process.cwd(), templateDir, "otp-template.hbs");
+    const templateSource = fs.readFileSync(templatePath, "utf-8");
+    const emailTemplate = Handlebars.compile(templateSource);
+
     const emailHtml = emailTemplate({
       OTP: otp,
       expirationMinutes: Math.round(OTP_EXPIRATION_SECONDS / 60),


### PR DESCRIPTION
- Refactored `server/routes/otp.ts` to move the `fs.readFileSync` and `Handlebars.compile` logic from the top level of the module into the `handleSendOtp` request handler.
- This prevents the file from being read during the Vite build process, which was the root cause of the build failure.
- Reverted the `build` script in `package.json` to its original order, as the build-order workaround is no longer necessary.